### PR TITLE
feat: refactor code to use serde_yaml instead of yaml-rust2

### DIFF
--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -58,8 +58,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - name: Install capnp
-        run: sudo apt-get install capnproto
       - name: Linting
         run: cargo clippy -- -D warnings
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ Cargo.lock
 
 .idea/workspace.xml
 .idea/tasks.xml
+.idea/vcs.xml
+.idea/modules.xml
+.idea/*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.5.4", features = ["derive"] }
-ureq = "2.9.7"
+clap = { version = "3.1.6", features = ["derive"] }
+ureq = "2.4.0"
 yaml-rust2 = "0.8.0"
+serde_yaml = "0.8.24"
+serde_json = "1.0.81"

--- a/README.MD
+++ b/README.MD
@@ -59,11 +59,12 @@ https:
 ```
 
 # Roadmap
-Updated 2024/05/27
+Updated 2024/06/02
 - [ ] Add functionality to specify expected response for get, post, etc.
 - [ ] Add support for RPC?
 - [ ] Add support for json file format
 - [ ] Add support for Auth tokens
+- [ ] Clean/Simplify logic for serializing yaml
 
 # Contributing
 Message me, I still have to work it out.


### PR DESCRIPTION
- refactor code to use serde_yaml instead of yaml-rust2
- update readme