### PR TITLE
chore: fix security audit of known, unmaintained dependencies

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,2 @@
+[advisories]
+ignore = ["RUSTSEC-2024-0320", "RUSTSEC-2021-0145"] # advisory IDs to ignore e.g. ["RUSTSEC-2019-0001", ...]


### PR DESCRIPTION
- fix the known, unmaintained dependencies that we chose to use on purpose that is blocking the security audit from succeeding.